### PR TITLE
fix missing padding when landlord is selected in header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -107,7 +107,7 @@ const UserRoleToggle = () => {
       <div
         className='absolute inset-y-0.5 w-1/2 bg-background rounded-full transition-all duration-300 ease-in-out shadow-sm'
         style={{
-          transform: userRole === 'tenant' ? 'translateX(0)' : 'translateX(100%)',
+          transform: userRole === 'tenant' ? 'translateX(0)' : 'translateX(calc(100% - 0.2rem))',
         }}
       ></div>
       <div className='relative flex'>


### PR DESCRIPTION
I attended the workshop you gave at Syntaxis and noticed an issue in one of your projects.
![image](https://github.com/user-attachments/assets/71b0b140-0b5f-4bb3-834a-69f4b2131d83)
this pull request fixes that.

Also unrelated but please run `npm audit fix` as i noticed some critical vulnerabilities when running `npm install`.